### PR TITLE
Use local model for increased performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 .venv
+models

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ env.bak/
 venv.bak/
 pythonenv*
 __pycache__
+models

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -22,9 +22,11 @@ services:
       - DATABASE_NAME=${DATABASE_NAME}
       - DATABASE_USER=${DATABASE_USER}
       - DATABASE_PASSWORD=${DATABASE_PASSWORD}
+      - ML_JAVA_MODEL=/usr/src/models/codebert-java
     working_dir: /usr/src/app
     volumes:
-      - './:/src'
+      - ./:/src
+      - ~/code-models:/usr/src/models
     networks:
       - backend_network
     labels:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -26,7 +26,7 @@ services:
     working_dir: /usr/src/app
     volumes:
       - ./:/src
-      - ~/code-models:/usr/src/models
+      - ~/develop/code-models:/usr/src/models
     networks:
       - backend_network
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,11 @@ services:
       - DATABASE_NAME=${DATABASE_NAME}
       - DATABASE_USER=${DATABASE_USER}
       - DATABASE_PASSWORD=${DATABASE_PASSWORD}
+      - ML_JAVA_MODEL=/usr/src/models/codebert-java
     working_dir: /usr/src/app
     volumes:
-      - './:/src'
+      - ./:/src
+      - ./models:/usr/src/models
     networks:
       - backend_network
     labels:


### PR DESCRIPTION
This PR enables using a pre-downloaded ML model for the similarity scores. The server will automatically fall back to its own download-and-caching if it does not find the model in the provided location.