### PR TITLE
Prevent server shutdown after /feedback_suggestions request

### DIFF
--- a/feedback-suggestion/src/app/endpoints/feedback_suggestions.py
+++ b/feedback-suggestion/src/app/endpoints/feedback_suggestions.py
@@ -27,7 +27,7 @@ class FeedbackSuggestionsRequest(BaseModel):
 
 
 @router.post("/feedback_suggestions")
-def get_feedback_suggestions_endpoint(
+async def get_feedback_suggestions_endpoint(
         request: FeedbackSuggestionsRequest,
         authorization: Union[str, None] = Header()
 ):
@@ -51,7 +51,7 @@ def get_feedback_suggestions_endpoint(
     # remove own participation
     db_feedbacks = [f for f in db_feedbacks if f.participation_id != request.participation_id]
 
-    suggested_feedbacks = get_feedback_suggestions(
+    suggested_feedbacks = await get_feedback_suggestions(
         function_blocks, db_feedbacks, include_code=request.include_code)
 
     return suggested_feedbacks

--- a/feedback-suggestion/src/app/feedback_suggestion/feedback_suggestions.py
+++ b/feedback-suggestion/src/app/feedback_suggestion/feedback_suggestions.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent
+from multiprocessing import get_context
 from typing import Dict, List, Iterator
 
 from .code_similarity_computer import CodeSimilarityComputer
@@ -64,7 +65,8 @@ async def get_feedback_suggestions(
     because it uses multiple processes to do the comparisons in parallel.
     """
     loop = asyncio.get_event_loop()
-    with concurrent.futures.ProcessPoolExecutor() as pool:
+    # https://github.com/tiangolo/fastapi/issues/1487#issuecomment-657290725
+    with concurrent.futures.ProcessPoolExecutor(mp_context=get_context("spawn")) as pool:
         results = await asyncio.gather(*[
             loop.run_in_executor(pool, get_feedback_suggestions_for_method,
                                  feedbacks, filepath, method, include_code)

--- a/feedback-suggestion/src/app/feedback_suggestion/feedback_suggestions.py
+++ b/feedback-suggestion/src/app/feedback_suggestion/feedback_suggestions.py
@@ -1,4 +1,5 @@
-from multiprocessing import Pool, cpu_count
+import asyncio
+import concurrent
 from typing import Dict, List, Iterator
 
 from .code_similarity_computer import CodeSimilarityComputer
@@ -51,7 +52,7 @@ def get_feedback_suggestions_for_method(
     return sorted(suggested, key=lambda x: x["similarity_score"], reverse=True)
 
 
-def get_feedback_suggestions(
+async def get_feedback_suggestions(
         function_blocks: Dict[str, List[MethodNode]],
         feedbacks: Iterator[Feedback],
         include_code: bool = False
@@ -62,14 +63,12 @@ def get_feedback_suggestions(
     This is quicker than calling get_feedback_suggestions_for_method for each method
     because it uses multiple processes to do the comparisons in parallel.
     """
-    pool = Pool(processes=cpu_count())
-    results = pool.starmap(get_feedback_suggestions_for_method,
-                           [
-                               (feedbacks, filepath, method, include_code)
-                               for filepath, methods in function_blocks.items()
-                               for method in methods
-                           ])
-    # this needs to be called for the server not to shut down after the request
-    pool.close()
-    pool.join()
+    loop = asyncio.get_event_loop()
+    with concurrent.futures.ProcessPoolExecutor() as pool:
+        results = await asyncio.gather(*[
+            loop.run_in_executor(pool, get_feedback_suggestions_for_method,
+                                 feedbacks, filepath, method, include_code)
+            for filepath, methods in function_blocks.items()
+            for method in methods
+        ])
     return [result for result_list in results for result in result_list]

--- a/feedback-suggestion/src/app/feedback_suggestion/feedback_suggestions.py
+++ b/feedback-suggestion/src/app/feedback_suggestion/feedback_suggestions.py
@@ -69,4 +69,7 @@ def get_feedback_suggestions(
                                for filepath, methods in function_blocks.items()
                                for method in methods
                            ])
+    # this needs to be called for the server not to shut down after the request
+    pool.close()
+    pool.join()
     return [result for result_list in results for result in result_list]


### PR DESCRIPTION
Until now, uvicorn shut down the server after any non-empty request to `/feedback_suggestions`. Now, this should not happen anymore.